### PR TITLE
docs(README): point Live Demo to Netlify/GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # KodeResto
 
+**Live Demo:** https://transcendent-rabanadas-a6001e.netlify.app/
+
 ![Pages Deploy](https://github.com/eriktong/KodeResto/actions/workflows/pages.yml/badge.svg) ![Last commit](https://img.shields.io/github/last-commit/eriktong/KodeResto) 
 
-**Live Demo:** [https://eriktong.github.io/KodeResto/](https://eriktong.github.io/KodeResto/)
 
 > Restaurant landing page (menu, specials, reservations).
 


### PR DESCRIPTION
This updates the README **Live Demo** link to: https://transcendent-rabanadas-a6001e.netlify.app/